### PR TITLE
fix OOB read on non-square inputs

### DIFF
--- a/rdo_bc_encoder.cpp
+++ b/rdo_bc_encoder.cpp
@@ -492,7 +492,7 @@ namespace rdo_bc
 		else
 		{
 			m_total_blocks_x = m_blocks_x;
-			m_total_blocks_y = m_blocks_x;
+			m_total_blocks_y = m_blocks_y;
 		}
 		if (m_params.m_red_to_alpha)
 			m_source_image_mips.red_to_alpha();

--- a/rdo_bc_encoder.cpp
+++ b/rdo_bc_encoder.cpp
@@ -487,7 +487,7 @@ namespace rdo_bc
 
 			// All mip levels fit in 2*x * 2*y blocks
 			m_total_blocks_x = m_blocks_x + m_blocks_x;
-			m_total_blocks_y = m_blocks_x + m_blocks_y;
+			m_total_blocks_y = m_blocks_y + m_blocks_y;
 		}
 		else
 		{

--- a/utils.cpp
+++ b/utils.cpp
@@ -201,15 +201,17 @@ void image_u8_mip::generate_mipmaps(mipmap_generation_method method)
 		int prev_level = i - 1;
 		// FIXME: Don't make a copy of the entire image...?
 		image_u8& prev = m_levels[prev_level];
-
-		image_u8 next(std::max(1u, prev.width() / 2), std::max(1u, prev.height() / 2));
-		const size_t w = next.width();
-		const size_t h = next.height();
+		//(m_source_image.width() + 3) & ~3
+		const size_t mw = std::max(1u, ((m_levels[0].width() >> i) + 3) & ~3);
+		const size_t mh = std::max(1u, ((m_levels[0].height() >> i) + 3) & ~3);
+		image_u8 next(mw, mh);
+		const size_t w = m_levels[0].width() >> i;
+		const size_t h = m_levels[0].height() >> i;
 		for (size_t y = 0; y < h; y++)
 		{
 			for (size_t x = 0; x < w; x++)
 			{
-				color_quad_u8 value0 = prev(x * 2 + 0, y * 2 + 0);
+				color_quad_u8 value0 = prev.get_clamped(x * 2 + 0, y * 2 + 0);
 				color_quad_u8 value1 = prev.get_clamped(x * 2 + 1, y * 2 + 0);
 				color_quad_u8 value2 = prev.get_clamped(x * 2 + 0, y * 2 + 1);
 				color_quad_u8 value3 = prev.get_clamped(x * 2 + 1, y * 2 + 1);


### PR DESCRIPTION
for some reason the repo doesn't have Issues enabled so I couldn't just report this normally, but there's a simple bug that prevents images that aren't square to work. I didn't test mip generation, but my input was 1024x6144.